### PR TITLE
Fixed issue #83, where cliff hanging wasn't stopping fall damage.

### DIFF
--- a/src/main/java/com/alrex/parcool/common/action/impl/ClingToCliff.java
+++ b/src/main/java/com/alrex/parcool/common/action/impl/ClingToCliff.java
@@ -30,6 +30,7 @@ public class ClingToCliff extends Action {
 		if (cling) {
 			clingTick++;
 			notClingTick = 0;
+			player.fallDistance = 0;
 		} else {
 			clingTick = 0;
 			notClingTick++;


### PR DESCRIPTION
Cliff hanging now resets your fall.