### PR TITLE
fix: updating  gradle validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       run: chmod +x ./gradlew
       
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v3
       
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Updating action to the maintained version (see details [here](https://github.com/gradle/wrapper-validation-action))