### PR TITLE
feat: decoupled camera cling-to-clif treatment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
     //compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api")
     compileOnly fg.deobf("curse.maven:BetterThirdPerson-435044:4177087")
-    compileOnly fg.deobf("curse.maven:ShoulderSurfing-243190:6387967")
+    compileOnly fg.deobf("curse.maven:shoulder-surfing-reloaded-243190:6496580")
 
     runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}")
     compileOnly fg.deobf("curse.maven:feathers-699933:4355016")

--- a/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingDecoupledCamera.java
+++ b/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingDecoupledCamera.java
@@ -1,0 +1,26 @@
+package com.alrex.parcool.extern.shouldersurfing;
+
+import com.alrex.parcool.common.action.impl.ClingToCliff;
+import com.alrex.parcool.common.capability.Parkourability;
+import com.github.exopandora.shouldersurfing.api.callback.ICameraCouplingCallback;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingPlugin;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingRegistrar;
+
+import net.minecraft.client.Minecraft;
+
+/**
+ * Compatibility class for the "Should Surfing" mod
+ */
+public class ShoulderSurfingDecoupledCamera implements ICameraCouplingCallback, IShoulderSurfingPlugin {
+
+    @Override
+    public boolean isForcingCameraCoupling(Minecraft mc) {
+        if (mc.player == null) return false;
+        return Parkourability.get(mc.player).isDoingAny(ClingToCliff.class);
+    }
+
+    @Override
+    public void register(IShoulderSurfingRegistrar registrar) {
+        registrar.registerCameraCouplingCallback(this);
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -47,6 +47,6 @@ side = "BOTH"
 [[dependencies.parcool]]
 modId = "shouldersurfing"
 mandatory = false
-versionRange = "[1.18.2-4.10.5,)"
+versionRange = "[1.18.2-4.11.0,)"
 ordering = "NONE"
 side = "BOTH"

--- a/src/main/resources/shouldersurfing_plugin.json
+++ b/src/main/resources/shouldersurfing_plugin.json
@@ -1,0 +1,3 @@
+{
+    "entrypoint": "com.alrex.parcool.common.compat.shoulderSurfing.ShoulderSurfingDecoupledCamera"
+}


### PR DESCRIPTION
The clinfg to cliff action doesn't have an intuitive behavior when combined with a decoupled camera. This PR uses the new Shoulder Surfing API to force a coupled camera whenever this action is used.

I'm opening this PR for 1.18.2 because Shoulder Surfing hasn't been updated for 1.16.5, 1.18.2 is the oldest version that received the new API. (I've asked about backporting here https://github.com/Exopandora/ShoulderSurfing/issues/302)

You can see how this suggestion works in the video below:

https://github.com/user-attachments/assets/c05ce827-b72a-4d49-ac8f-98bbb6d36e6e



I also have a suggestion for the dodge action. It's not working well with a decoupled camera because the direction the player is facing often does not correspond to the movement keys pressed (it's hard to explain or to show through a video, maybe is better to try it to see for yourself). I've decided to open another PR for it if you agree, as it's a bit disruptive:
When the camera is decoupled, dodging using double tap will only go forward (because the double tap makes the character turn to the tapped direction), and dodging using the dodge key will only go back. I'm not really happy with this idea because it can be confusing for the player (but the current behavior is also confusing), but I haven't found a good solution yet. The big issue is that, when the camera is decoupled, pressing some direction makes the character turn, which messes up any solution I tried to solve the dodge direction. Another idea I had is to not allow any movement when dodge is being performed, but it's also not satisfactory, as the player can press the movement key a some ticks before the dodge one, so a turning can already be happening.

If you want to simulate the issue:

* Use a decoupled camera with shoulder surfing;
* Move the player in the right direction, making it face right;
* Try to dodge using double tap or dodge key to every direction;
* Repeat the process facing each direction