### PR TITLE
feat: adapting dodge to decoupled camera

### DIFF
--- a/src/main/java/com/alrex/parcool/client/input/KeyBindings.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyBindings.java
@@ -1,6 +1,7 @@
 package com.alrex.parcool.client.input;
 
-import com.alrex.parcool.utilities.MathUtil;
+import com.alrex.parcool.extern.AdditionalMods;
+import com.alrex.parcool.utilities.VectorUtil;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
@@ -13,8 +14,6 @@ import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.client.settings.KeyModifier;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-
-import org.antlr.v4.parse.ANTLRParser.finallyClause_return;
 import org.lwjgl.glfw.GLFW;
 
 @OnlyIn(Dist.CLIENT)
@@ -54,9 +53,10 @@ public class KeyBindings {
 
 	public static Vec3 getCurrentMoveVector() {
 		var vector = Minecraft.getInstance().player.input.getMoveVector();
-		if (MathUtil.isZero(vector)) return Vec3.ZERO;
+		if (VectorUtil.isZero(vector)) return Vec3.ZERO;
 		double length = vector.length();
-		return new Vec3(vector.x / length, 0, vector.y / length);
+		var result = new Vec3(vector.x / length, 0, vector.y / length);
+		return result;
 	}
 
 	public static Vec3 getForwardVector() {

--- a/src/main/java/com/alrex/parcool/client/input/KeyBindings.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyBindings.java
@@ -1,9 +1,11 @@
 package com.alrex.parcool.client.input;
 
+import com.alrex.parcool.utilities.MathUtil;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.ClientRegistry;
@@ -11,6 +13,8 @@ import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.client.settings.KeyModifier;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+import org.antlr.v4.parse.ANTLRParser.finallyClause_return;
 import org.lwjgl.glfw.GLFW;
 
 @OnlyIn(Dist.CLIENT)
@@ -33,6 +37,7 @@ public class KeyBindings {
 	private static final KeyMapping keyBindHorizontalWallRun = new KeyMapping("key.parcool.HorizontalWallRun", GLFW.GLFW_KEY_R, "key.categories.parcool");
 	private static final KeyMapping keyBindQuickTurn = new KeyMapping("key.parcool.QuickTurn", GLFW.GLFW_KEY_UNKNOWN, "key.categories.parcool");
 	private static final KeyMapping keyBindOpenSettings = new KeyMapping("key.parcool.openSetting", KeyConflictContext.UNIVERSAL, KeyModifier.ALT, InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_P, "key.categories.parcool");
+	private static final Vec3 forwardVector = new Vec3(0, 0, 1);
 
 	public static KeyMapping getKeySprint() {
 		return settings.keySprint;
@@ -45,6 +50,17 @@ public class KeyBindings {
 
 	public static KeyMapping getKeySneak() {
 		return settings.keyShift;
+	}
+
+	public static Vec3 getCurrentMoveVector() {
+		var vector = Minecraft.getInstance().player.input.getMoveVector();
+		if (MathUtil.isZero(vector)) return Vec3.ZERO;
+		double length = vector.length();
+		return new Vec3(vector.x / length, 0, vector.y / length);
+	}
+
+	public static Vec3 getForwardVector() {
+		return forwardVector;
 	}
 
     public static Boolean isAnyMovingKeyDown() {

--- a/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
@@ -1,13 +1,12 @@
 package com.alrex.parcool.client.input;
 
-import com.github.exopandora.shouldersurfing.math.Vec2f;
-
 import net.minecraft.client.KeyMapping;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.phys.Vec3;
 
 @OnlyIn(Dist.CLIENT)
 public class KeyRecorder {
@@ -28,7 +27,7 @@ public class KeyRecorder {
 	public static final KeyState keyQuickTurn = new KeyState();
 	public static final KeyState keyFlipping = new KeyState();
     public static final KeyState keyBindGrabWall = new KeyState();
-	public static Vec2f lastDirection = null;
+	public static Vec3 lastDirection = null;
 
 	@SubscribeEvent
 	public static void onClientTick(TickEvent.ClientTickEvent event) {
@@ -54,7 +53,7 @@ public class KeyRecorder {
 		recordMovingVector(KeyBindings.isAnyMovingKeyDown());
 	}
 
-	public static Vec2f getLastDirection() {
+	public static Vec3 getLastMoveVector() {
 		return lastDirection;
 	}
 
@@ -78,11 +77,8 @@ public class KeyRecorder {
         record(keyBinding.isDown(), state);
     }
 
-	private static void recordMovingVector(boolean isDown) {
-		if (KeyBindings.isAnyMovingKeyDown()) {
-			var vector = Minecraft.getInstance().player.input.getMoveVector();
-			lastDirection = new Vec2f(vector.x, vector.y);
-		}
+	private static void recordMovingVector(boolean isMoving) {
+		if (isMoving) lastDirection = KeyBindings.getCurrentMoveVector();
 	}
 
 	public static class KeyState {

--- a/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
@@ -1,11 +1,13 @@
 package com.alrex.parcool.client.input;
 
+import com.github.exopandora.shouldersurfing.math.Vec2f;
+
 import net.minecraft.client.KeyMapping;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-
+import net.minecraft.client.Minecraft;
 
 @OnlyIn(Dist.CLIENT)
 public class KeyRecorder {
@@ -26,6 +28,7 @@ public class KeyRecorder {
 	public static final KeyState keyQuickTurn = new KeyState();
 	public static final KeyState keyFlipping = new KeyState();
     public static final KeyState keyBindGrabWall = new KeyState();
+	public static Vec2f lastDirection = null;
 
 	@SubscribeEvent
 	public static void onClientTick(TickEvent.ClientTickEvent event) {
@@ -48,6 +51,11 @@ public class KeyRecorder {
 		record(KeyBindings.getKeyQuickTurn(), keyQuickTurn);
 		record(KeyBindings.getKeyFlipping(), keyFlipping);
         record(KeyBindings.getKeyGrabWall(), keyBindGrabWall);
+		recordMovingVector(KeyBindings.isAnyMovingKeyDown());
+	}
+
+	public static Vec2f getLastDirection() {
+		return lastDirection;
 	}
 
     private static void record(Boolean isDown, KeyState state) {
@@ -69,6 +77,13 @@ public class KeyRecorder {
     private static void record(KeyMapping keyBinding, KeyState state) {
         record(keyBinding.isDown(), state);
     }
+
+	private static void recordMovingVector(boolean isDown) {
+		if (KeyBindings.isAnyMovingKeyDown()) {
+			var vector = Minecraft.getInstance().player.input.getMoveVector();
+			lastDirection = new Vec2f(vector.x, vector.y);
+		}
+	}
 
 	public static class KeyState {
 		private boolean pressed = false;

--- a/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
@@ -50,7 +50,7 @@ public class KeyRecorder {
 		record(KeyBindings.getKeyWallJump(), keyWallJump);
 		record(KeyBindings.getKeyQuickTurn(), keyQuickTurn);
 		record(KeyBindings.getKeyFlipping(), keyFlipping);
-        record(KeyBindings.getKeyGrabWall(), keyBindGrabWall);
+		record(KeyBindings.getKeyGrabWall(), keyBindGrabWall);
 		recordMovingVector(KeyBindings.isAnyMovingKeyDown());
 	}
 

--- a/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
@@ -1,5 +1,7 @@
 package com.alrex.parcool.client.input;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.client.KeyMapping;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -53,6 +55,7 @@ public class KeyRecorder {
 		recordMovingVector(KeyBindings.isAnyMovingKeyDown());
 	}
 
+	@Nullable
 	public static Vec3 getLastMoveVector() {
 		return lastDirection;
 	}

--- a/src/main/java/com/alrex/parcool/common/action/impl/Dodge.java
+++ b/src/main/java/com/alrex/parcool/common/action/impl/Dodge.java
@@ -194,8 +194,7 @@ public class Dodge extends Action {
 				.normalize()
 				.scale(0.9 * getSpeedModifier(parkourability.getActionInfo()));
 		player.setDeltaMovement(dodgeVec);
-		var cameraDecoupled = AdditionalMods.isCameraDecoupled();
-		if (cameraDecoupled) {
+		if ( AdditionalMods.isCameraDecoupled()) {
 			float yaw = (float) Math.toDegrees(Math.atan2(-dodgeVec.x, dodgeVec.z));
 			player.setYRot(yaw);
 		}

--- a/src/main/java/com/alrex/parcool/extern/AdditionalMods.java
+++ b/src/main/java/com/alrex/parcool/extern/AdditionalMods.java
@@ -36,4 +36,8 @@ public enum AdditionalMods {
     public static void init() {
         Arrays.stream(values()).map(AdditionalMods::get).forEach(ModManager::init);
     }
+
+    public static boolean isCameraDecoupled() {
+        return shoulderSurfing().isCameraDecoupled() || betterThirdPerson().isCameraDecoupled();
+    }
 }

--- a/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
+++ b/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
@@ -1,9 +1,15 @@
 package com.alrex.parcool.extern.betterthirdperson;
 
 import com.alrex.parcool.common.action.impl.Dodge;
+import com.alrex.parcool.extern.AdditionalMods;
 import com.alrex.parcool.extern.ModManager;
+import com.alrex.parcool.utilities.VectorUtil;
+
 import io.socol.betterthirdperson.BetterThirdPerson;
+import io.socol.betterthirdperson.api.CustomCameraManager;
+import io.socol.betterthirdperson.api.util.AngleUtils;
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.phys.Vec3;
 
 public class BetterThirdPersonManager extends ModManager {
     public BetterThirdPersonManager() {
@@ -18,10 +24,5 @@ public class BetterThirdPersonManager extends ModManager {
         return isInstalled()
             && !Minecraft.getInstance().options.getCameraType().isFirstPerson()
             && BetterThirdPerson.getCameraManager().hasCustomCamera();
-    }
-
-    public void cancelTurn() {
-        var cameraManager = BetterThirdPerson.getCameraManager();
-        cameraManager.stopPlayerTurning();
     }
 }

--- a/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
+++ b/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
@@ -2,11 +2,8 @@ package com.alrex.parcool.extern.betterthirdperson;
 
 import com.alrex.parcool.common.action.impl.Dodge;
 import com.alrex.parcool.extern.ModManager;
-import com.alrex.parcool.utilities.MathUtil;
 import io.socol.betterthirdperson.BetterThirdPerson;
-import io.socol.betterthirdperson.api.CustomCamera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 
 public class BetterThirdPersonManager extends ModManager {
     public BetterThirdPersonManager() {
@@ -14,30 +11,17 @@ public class BetterThirdPersonManager extends ModManager {
     }
 
     public Dodge.DodgeDirection handleCustomCameraRotationForDodge(Dodge.DodgeDirection direction) {
-        if (!isInstalled()) return direction;
-        if (!Minecraft.getInstance().options.getCameraType().isFirstPerson()) {
-            LocalPlayer player = Minecraft.getInstance().player;
-            if (player == null) return direction;
-            if (!BetterThirdPerson.getCameraManager().hasCustomCamera()) return direction;
-            CustomCamera camera = BetterThirdPerson.getCameraManager().getCustomCamera();
-            float yaw = MathUtil.normalizeDegree(camera.getPlayerRotation().getYaw() - camera.getCameraRotation().getYaw());
-            float yawAbs = Math.abs(yaw);
-            if (yawAbs < 45) {
-                return direction;
-            } else if (yawAbs > 135) {
-                return direction.inverse();
-            } else if (yaw < 0) {
-                return direction.right();
-            } else {
-                return direction.left();
-            }
-        }
-        return direction;
+        return isCameraDecoupled() ? Dodge.DodgeDirection.Front : direction;
     }
 
     public boolean isCameraDecoupled() {
-        if (!isInstalled()) return false;
-        if (!BetterThirdPerson.getCameraManager().hasCustomCamera()) return false;
-        return true;
+        return isInstalled()
+            && !Minecraft.getInstance().options.getCameraType().isFirstPerson()
+            && BetterThirdPerson.getCameraManager().hasCustomCamera();
+    }
+
+    public void cancelTurn() {
+        var cameraManager = BetterThirdPerson.getCameraManager();
+        cameraManager.stopPlayerTurning();
     }
 }

--- a/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
+++ b/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
@@ -34,4 +34,10 @@ public class BetterThirdPersonManager extends ModManager {
         }
         return direction;
     }
+
+    public boolean isCameraDecoupled() {
+        if (!isInstalled()) return false;
+        if (!BetterThirdPerson.getCameraManager().hasCustomCamera()) return false;
+        return true;
+    }
 }

--- a/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
+++ b/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
@@ -11,15 +11,13 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.phys.Vec3;
 
 public class ShoulderSurfingManager extends ModManager {
-    private static Minecraft mc = Minecraft.getInstance();
-
     public ShoulderSurfingManager() {
         super("shouldersurfing");
     }
 
     public Dodge.DodgeDirection handleCustomCameraRotationForDodge(Dodge.DodgeDirection direction) {
         if (!isInstalled()) return direction;
-        if (mc.options.getCameraType().isFirstPerson()) return direction;
+        if (Minecraft.getInstance().options.getCameraType().isFirstPerson()) return direction;
         if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return direction;
         if (isCameraDecoupled()) return DodgeDirection.Front;
         LocalPlayer player = Minecraft.getInstance().player;
@@ -40,7 +38,7 @@ public class ShoulderSurfingManager extends ModManager {
 
     public float getCameraAngle() {
         if (!isInstalled()) return 0;
-        if (mc.options.getCameraType().isFirstPerson()) return 0;
+        if (Minecraft.getInstance().options.getCameraType().isFirstPerson()) return 0;
         if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return 0;
         IShoulderSurfingCamera camera = ShoulderSurfing.getInstance().getCamera();
         return camera.getYRot();

--- a/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
+++ b/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
@@ -1,37 +1,48 @@
 package com.alrex.parcool.extern.shouldersurfing;
 
 import com.alrex.parcool.common.action.impl.Dodge;
+import com.alrex.parcool.common.action.impl.Dodge.DodgeDirection;
 import com.alrex.parcool.extern.ModManager;
 import com.alrex.parcool.utilities.MathUtil;
 import com.github.exopandora.shouldersurfing.api.client.IShoulderSurfingCamera;
 import com.github.exopandora.shouldersurfing.api.client.ShoulderSurfing;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.phys.Vec3;
 
 public class ShoulderSurfingManager extends ModManager {
+    private static Minecraft mc = Minecraft.getInstance();
+
     public ShoulderSurfingManager() {
         super("shouldersurfing");
     }
 
     public Dodge.DodgeDirection handleCustomCameraRotationForDodge(Dodge.DodgeDirection direction) {
         if (!isInstalled()) return direction;
-        if (!Minecraft.getInstance().options.getCameraType().isFirstPerson()) {
-            if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return direction;
-            LocalPlayer player = Minecraft.getInstance().player;
-            if (player == null) return direction;
-            IShoulderSurfingCamera camera = ShoulderSurfing.getInstance().getCamera();
-            float yaw = MathUtil.normalizeDegree(camera.getYRot() - player.getYRot());
-            float yawAbs = Math.abs(yaw);
-            if (yawAbs < 45) {
-                return direction;
-            } else if (yawAbs > 135) {
-                return direction.inverse();
-            } else if (yaw < 0) {
-                return direction.left();
-            } else {
-                return direction.right();
-            }
-        }
-        return direction;
+        if (mc.options.getCameraType().isFirstPerson()) return direction;
+        if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return direction;
+        if (isCameraDecoupled()) return DodgeDirection.Front;
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return direction;
+        IShoulderSurfingCamera camera = ShoulderSurfing.getInstance().getCamera();
+        float yaw = MathUtil.normalizeDegree(camera.getYRot() - player.getYRot());
+        float yawAbs = Math.abs(yaw);
+        if (yawAbs < 45) return direction;
+        if (yawAbs > 135) return direction.inverse();
+        if (yaw < 0) return direction.left();
+        return direction.right();
+    }
+
+    public Boolean isCameraDecoupled() {
+        if (!isInstalled()) return false;
+        return ShoulderSurfing.getInstance().isCameraDecoupled();
+    }
+
+    public float getCameraAngle() {
+        if (!isInstalled()) return 0;
+        if (mc.options.getCameraType().isFirstPerson()) return 0;
+        if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return 0;
+        IShoulderSurfingCamera camera = ShoulderSurfing.getInstance().getCamera();
+        return camera.getYRot();
     }
 }

--- a/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
+++ b/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
@@ -3,12 +3,8 @@ package com.alrex.parcool.extern.shouldersurfing;
 import com.alrex.parcool.common.action.impl.Dodge;
 import com.alrex.parcool.common.action.impl.Dodge.DodgeDirection;
 import com.alrex.parcool.extern.ModManager;
-import com.alrex.parcool.utilities.MathUtil;
-import com.github.exopandora.shouldersurfing.api.client.IShoulderSurfingCamera;
 import com.github.exopandora.shouldersurfing.api.client.ShoulderSurfing;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.world.phys.Vec3;
 
 public class ShoulderSurfingManager extends ModManager {
     public ShoulderSurfingManager() {
@@ -16,31 +12,13 @@ public class ShoulderSurfingManager extends ModManager {
     }
 
     public Dodge.DodgeDirection handleCustomCameraRotationForDodge(Dodge.DodgeDirection direction) {
-        if (!isInstalled()) return direction;
-        if (Minecraft.getInstance().options.getCameraType().isFirstPerson()) return direction;
-        if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return direction;
-        if (isCameraDecoupled()) return DodgeDirection.Front;
-        LocalPlayer player = Minecraft.getInstance().player;
-        if (player == null) return direction;
-        IShoulderSurfingCamera camera = ShoulderSurfing.getInstance().getCamera();
-        float yaw = MathUtil.normalizeDegree(camera.getYRot() - player.getYRot());
-        float yawAbs = Math.abs(yaw);
-        if (yawAbs < 45) return direction;
-        if (yawAbs > 135) return direction.inverse();
-        if (yaw < 0) return direction.left();
-        return direction.right();
+        return isCameraDecoupled() ? DodgeDirection.Front : direction;
     }
 
     public Boolean isCameraDecoupled() {
-        if (!isInstalled()) return false;
-        return ShoulderSurfing.getInstance().isCameraDecoupled();
-    }
-
-    public float getCameraAngle() {
-        if (!isInstalled()) return 0;
-        if (Minecraft.getInstance().options.getCameraType().isFirstPerson()) return 0;
-        if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return 0;
-        IShoulderSurfingCamera camera = ShoulderSurfing.getInstance().getCamera();
-        return camera.getYRot();
+        return isInstalled()
+            && !Minecraft.getInstance().options.getCameraType().isFirstPerson()
+            && ShoulderSurfing.getInstance().isShoulderSurfing()
+            && ShoulderSurfing.getInstance().isCameraDecoupled();
     }
 }

--- a/src/main/java/com/alrex/parcool/utilities/MathUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/MathUtil.java
@@ -1,5 +1,8 @@
 package com.alrex.parcool.utilities;
 
+import com.github.exopandora.shouldersurfing.math.Vec2f;
+import net.minecraft.util.Mth;
+import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 
 public class MathUtil {
@@ -18,4 +21,22 @@ public class MathUtil {
     public static float normalizeDegree(float angle) {
         return (float) (angle - 360f * Math.floor((angle + 180f) / 360f));
     }
+	
+	public static Vec3 rotateYDegrees(Vec3 vector, float baseAngle)
+	{
+		var angle = baseAngle * Mth.DEG_TO_RAD;
+		return new Vec3(vector.x * Mth.cos(angle) - vector.z * Mth.sin(angle), vector.y, vector.x * Mth.sin(angle) + vector.z * Mth.cos(angle));
+	}
+
+	public static float toYaw(Vec3 vector) {
+		return (float)Math.toDegrees(Math.atan2(-vector.x, vector.z));
+	}
+
+	public static boolean isZero(Vec3 vector) {
+		return vector.x == 0 && vector.y == 0 && vector.z == 0;
+	}
+
+	public static boolean isZero(Vec2 vector) {
+		return vector.x == 0 && vector.y == 0;
+	}
 }

--- a/src/main/java/com/alrex/parcool/utilities/MathUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/MathUtil.java
@@ -1,5 +1,7 @@
 package com.alrex.parcool.utilities;
 
+import net.minecraft.world.phys.Vec3;
+
 public class MathUtil {
 	public static float squaring(float value) {
 		return value * value;

--- a/src/main/java/com/alrex/parcool/utilities/MathUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/MathUtil.java
@@ -1,10 +1,5 @@
 package com.alrex.parcool.utilities;
 
-import com.github.exopandora.shouldersurfing.math.Vec2f;
-import net.minecraft.util.Mth;
-import net.minecraft.world.phys.Vec2;
-import net.minecraft.world.phys.Vec3;
-
 public class MathUtil {
 	public static float squaring(float value) {
 		return value * value;
@@ -21,22 +16,4 @@ public class MathUtil {
     public static float normalizeDegree(float angle) {
         return (float) (angle - 360f * Math.floor((angle + 180f) / 360f));
     }
-	
-	public static Vec3 rotateYDegrees(Vec3 vector, float baseAngle)
-	{
-		var angle = baseAngle * Mth.DEG_TO_RAD;
-		return new Vec3(vector.x * Mth.cos(angle) - vector.z * Mth.sin(angle), vector.y, vector.x * Mth.sin(angle) + vector.z * Mth.cos(angle));
-	}
-
-	public static float toYaw(Vec3 vector) {
-		return (float)Math.toDegrees(Math.atan2(-vector.x, vector.z));
-	}
-
-	public static boolean isZero(Vec3 vector) {
-		return vector.x == 0 && vector.y == 0 && vector.z == 0;
-	}
-
-	public static boolean isZero(Vec2 vector) {
-		return vector.x == 0 && vector.y == 0;
-	}
 }

--- a/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
@@ -1,5 +1,7 @@
 package com.alrex.parcool.utilities;
 
+import net.minecraft.util.Mth;
+import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 
 public class VectorUtil {
@@ -17,5 +19,23 @@ public class VectorUtil {
 
 	public static Vec3 fromYawDegree(double degree) {
 		return new Vec3(-Math.sin(Math.toRadians(degree)), 0, Math.cos(Math.toRadians(degree)));
+	}
+	
+	public static Vec3 rotateYDegrees(Vec3 vector, float baseAngle)
+	{
+		var angle = baseAngle * Mth.DEG_TO_RAD;
+		return new Vec3(vector.x * Mth.cos(angle) - vector.z * Mth.sin(angle), vector.y, vector.x * Mth.sin(angle) + vector.z * Mth.cos(angle));
+	}
+
+	public static float toYaw(Vec3 vector) {
+		return (float)Math.toDegrees(Math.atan2(-vector.x, vector.z));
+	}
+
+	public static boolean isZero(Vec3 vector) {
+		return vector.x == 0 && vector.y == 0 && vector.z == 0;
+	}
+
+	public static boolean isZero(Vec2 vector) {
+		return vector.x == 0 && vector.y == 0;
 	}
 }


### PR DESCRIPTION
If the camera is decoupled, the dodge action will always be a forward roll in the direction the user inputs. The player's yRot is also set to face the right angle after rolling. This makes sense because the player always turns in your input direction when using a decoupled camera.

This is a work in progress.  I need to adjust the dodgeVec angle so it is projected correctly in the Minecraft coordinates, but I'm having a hard time to achieve that. I'm opening this draft more to validate the idea with you, @alRex-U, so I can decide if I dedicate time to get the math right.

Here's a video of how it should work (unfortunately, it only works when the camera is facing that direction)


https://github.com/user-attachments/assets/31fe62fe-e6b1-4364-b3de-a97ed3d7ed2f

See that diagonal dodging also works with this idea. I used a keyboard to demonstrate, but with an analog stick of a gamepad it is even better, as the angles are continuous.

