### PR TITLE
fix: prevent null pointer exception at IsForcingCameraCoupling

### DIFF
--- a/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingDecoupledCamera.java
+++ b/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingDecoupledCamera.java
@@ -16,7 +16,9 @@ public class ShoulderSurfingDecoupledCamera implements ICameraCouplingCallback, 
     @Override
     public boolean isForcingCameraCoupling(Minecraft mc) {
         if (mc.player == null) return false;
-        return Parkourability.get(mc.player).isDoingAny(ClingToCliff.class);
+        var parkourability = Parkourability.get(mc.player);
+        if (parkourability == null) return false;
+        return parkourability.isDoingAny(ClingToCliff.class);
     }
 
     @Override


### PR DESCRIPTION
Parkourability.get could return null, which would throw an error. Treating the case.

This is related  to the PR https://github.com/Exopandora/ShoulderSurfing/pull/307 I also opened in ShoulderSurfing,
and with the issue https://github.com/Exopandora/ShoulderSurfing/issues/305 there.

Edit: also solves https://github.com/alRex-U/ParCool/issues/379.

@alRex-U sorry for letting this one pass.