### PR TITLE
1.16.5 dodge shouldersurfing

### DIFF
--- a/src/main/java/com/alrex/parcool/client/input/KeyBindings.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyBindings.java
@@ -4,6 +4,8 @@ import net.minecraft.client.GameSettings;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.client.util.InputMappings;
+import net.minecraft.util.math.vector.Vector2f;
+import net.minecraft.util.math.vector.Vector3d;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.settings.KeyConflictContext;
@@ -12,6 +14,8 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import org.lwjgl.glfw.GLFW;
+
+import com.alrex.parcool.utilities.VectorUtil;
 
 @OnlyIn(Dist.CLIENT)
 public class KeyBindings {
@@ -33,6 +37,7 @@ public class KeyBindings {
 	private static final KeyBinding keyBindHorizontalWallRun = new KeyBinding("key.parcool.HorizontalWallRun", GLFW.GLFW_KEY_R, "key.categories.parcool");
 	private static final KeyBinding keyBindQuickTurn = new KeyBinding("key.parcool.QuickTurn", GLFW.GLFW_KEY_UNKNOWN, "key.categories.parcool");
 	private static final KeyBinding keyBindOpenSettings = new KeyBinding("key.parcool.openSetting", KeyConflictContext.UNIVERSAL, KeyModifier.ALT, InputMappings.Type.KEYSYM, GLFW.GLFW_KEY_P, "key.categories.parcool");
+	private static final Vector3d forwardVector = new Vector3d(0, 0, 1);
 
 	public static KeyBinding getKeySprint() {
 		return settings.keySprint;
@@ -45,6 +50,18 @@ public class KeyBindings {
 
 	public static KeyBinding getKeySneak() {
 		return settings.keyShift;
+	}
+
+	public static Vector3d getCurrentMoveVector() {
+		Vector2f vector = Minecraft.getInstance().player.input.getMoveVector();
+		if (VectorUtil.isZero(vector)) return Vector3d.ZERO;
+		double length = VectorUtil.getLength(vector);
+		Vector3d result = new Vector3d(vector.x / length, 0, vector.y / length);
+		return result;
+	}
+
+	public static Vector3d getForwardVector() {
+		return forwardVector;
 	}
 
 	public static Boolean isAnyMovingKeyDown() {

--- a/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
@@ -1,11 +1,12 @@
 package com.alrex.parcool.client.input;
 
+import javax.annotation.Nullable;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.util.math.vector.Vector3d;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-
 
 @OnlyIn(Dist.CLIENT)
 public class KeyRecorder {
@@ -26,6 +27,7 @@ public class KeyRecorder {
 	public static final KeyState keyQuickTurn = new KeyState();
 	public static final KeyState keyFlipping = new KeyState();
 	public static final KeyState keyBindGrabWall = new KeyState();
+	public static Vector3d lastDirection = null;
 
 	@SubscribeEvent
 	public static void onClientTick(TickEvent.ClientTickEvent event) {
@@ -48,6 +50,12 @@ public class KeyRecorder {
 		record(KeyBindings.getKeyQuickTurn(), keyQuickTurn);
 		record(KeyBindings.getKeyFlipping(), keyFlipping);
 		record(KeyBindings.getKeyGrabWall(), keyBindGrabWall);
+		recordMovingVector(KeyBindings.isAnyMovingKeyDown());
+	}
+
+	@Nullable
+	public static Vector3d getLastMoveVector() {
+		return lastDirection;
 	}
 
 	private static void record(Boolean isDown, KeyState state) {
@@ -68,6 +76,10 @@ public class KeyRecorder {
 
 	private static void record(KeyBinding keyBinding, KeyState state) {
 		record(keyBinding.isDown(), state);
+	}
+
+	private static void recordMovingVector(boolean isMoving) {
+		if (isMoving) lastDirection = KeyBindings.getCurrentMoveVector();
 	}
 
 	public static class KeyState {

--- a/src/main/java/com/alrex/parcool/common/action/impl/Dodge.java
+++ b/src/main/java/com/alrex/parcool/common/action/impl/Dodge.java
@@ -7,13 +7,17 @@ import com.alrex.parcool.client.input.KeyRecorder;
 import com.alrex.parcool.common.action.Action;
 import com.alrex.parcool.common.action.BehaviorEnforcer;
 import com.alrex.parcool.common.action.StaminaConsumeTiming;
+import com.alrex.parcool.common.action.impl.Dodge.DodgeDirection;
 import com.alrex.parcool.common.capability.Animation;
 import com.alrex.parcool.common.capability.IStamina;
 import com.alrex.parcool.common.capability.Parkourability;
 import com.alrex.parcool.common.info.ActionInfo;
 import com.alrex.parcool.config.ParCoolConfig;
 import com.alrex.parcool.extern.AdditionalMods;
+import com.alrex.parcool.utilities.EntityUtil;
 import com.alrex.parcool.utilities.VectorUtil;
+
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.vector.Vector3d;
@@ -127,6 +131,7 @@ public class Dodge extends Action {
 	public boolean canStart(PlayerEntity player, Parkourability parkourability, IStamina stamina, ByteBuffer startInfo) {
 		boolean enabledDoubleTap = ParCoolConfig.Client.Booleans.EnableDoubleTappingForDodge.get();
 		DodgeDirection direction = null;
+		Vector3d dodgeVec = KeyRecorder.getLastMoveVector();
 		if (enabledDoubleTap) {
 			if (KeyRecorder.keyBack.isDoubleTapped()) direction = DodgeDirection.Back;
 			if (KeyRecorder.keyLeft.isDoubleTapped()) direction = DodgeDirection.Left;
@@ -137,11 +142,14 @@ public class Dodge extends Action {
 			if (KeyBindings.isKeyForwardDown()) direction = DodgeDirection.Front;
 			if (KeyBindings.isKeyLeftDown()) direction = DodgeDirection.Left;
 			if (KeyBindings.isKeyRightDown()) direction = DodgeDirection.Right;
+			if (direction != null) dodgeVec = KeyBindings.getCurrentMoveVector();
 		}
-		if (direction == null) return false;
+		if (direction == null || dodgeVec == null) return false;
 		direction = AdditionalMods.betterThirdPerson().handleCustomCameraRotationForDodge(direction);
 		direction = AdditionalMods.shoulderSurfingManager().handleCustomCameraRotationForDodge(direction);
 		startInfo.putInt(direction.ordinal());
+		startInfo.putDouble(dodgeVec.x);
+		startInfo.putDouble(dodgeVec.z);
 		return ((parkourability.getAdditionalProperties().getLandingTick() > 5 || parkourability.getAdditionalProperties().getPreviousNotLandingTick() < 2)
 				&& player.isOnGround()
 				&& !isInSuccessiveCoolDown(parkourability.getActionInfo())
@@ -171,32 +179,23 @@ public class Dodge extends Action {
 	@Override
 	public void onStartInLocalClient(PlayerEntity player, Parkourability parkourability, IStamina stamina, ByteBuffer startData) {
 		dodgeDirection = DodgeDirection.values()[startData.getInt()];
+		Vector3d dodgeVec = new Vector3d(startData.getDouble(), 0, startData.getDouble());
 		coolTime = getMaxCoolTime(parkourability.getActionInfo());
 		if (successivelyCount < getMaxSuccessiveDodge(parkourability.getActionInfo())) {
 			successivelyCount++;
 		}
-		if (ParCoolConfig.Client.Booleans.EnableActionSounds.get())
-            player.playSound(SoundEvents.DODGE.get(), 1f, 1f);
+		if (ParCoolConfig.Client.Booleans.EnableActionSounds.get()) {
+			player.playSound(SoundEvents.DODGE.get(), 1f, 1f);
+		}
 		successivelyCoolTick = getSuccessiveCoolTime(parkourability.getActionInfo());
 
 		if (!player.isOnGround()) return;
-		Vector3d lookVec = VectorUtil.fromYawDegree(player.getYHeadRot());
-		Vector3d dodgeVec = Vector3d.ZERO;
-		switch (dodgeDirection) {
-			case Front:
-				dodgeVec = lookVec;
-				break;
-			case Back:
-				dodgeVec = lookVec.reverse();
-				break;
-			case Right:
-				dodgeVec = lookVec.yRot((float) Math.PI / -2);
-				break;
-			case Left:
-				dodgeVec = lookVec.yRot((float) Math.PI / 2);
-				break;
+		float cameraYRot = Minecraft.getInstance().getCameraEntity().yRot;
+		dodgeVec = VectorUtil.rotateYDegrees(dodgeVec, cameraYRot);
+		dodgeVec = dodgeVec.scale(0.9 * getSpeedModifier(parkourability.getActionInfo()));
+		if (AdditionalMods.isCameraDecoupled()) {
+			EntityUtil.setYRot(player, VectorUtil.toYaw(dodgeVec));
 		}
-		dodgeVec = dodgeVec.scale(.9 * getSpeedModifier(parkourability.getActionInfo()));
 		player.setDeltaMovement(dodgeVec);
 
 		Animation animation = Animation.get(player);

--- a/src/main/java/com/alrex/parcool/extern/AdditionalMods.java
+++ b/src/main/java/com/alrex/parcool/extern/AdditionalMods.java
@@ -30,4 +30,8 @@ public enum AdditionalMods {
     public static void init() {
         Arrays.stream(values()).map(AdditionalMods::get).forEach(ModManager::init);
     }
+
+    public static boolean isCameraDecoupled() {
+        return shoulderSurfingManager().isCameraDecoupled() || betterThirdPerson().isCameraDecoupled();
+    }
 }

--- a/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
+++ b/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
@@ -1,12 +1,10 @@
 package com.alrex.parcool.extern.betterthirdperson;
 
 import com.alrex.parcool.common.action.impl.Dodge;
+import com.alrex.parcool.extern.AdditionalMods;
 import com.alrex.parcool.extern.ModManager;
-import com.alrex.parcool.utilities.MathUtil;
 import io.socol.betterthirdperson.BetterThirdPerson;
-import io.socol.betterthirdperson.api.CustomCamera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.entity.player.ClientPlayerEntity;
 
 public class BetterThirdPersonManager extends ModManager {
     public BetterThirdPersonManager() {
@@ -14,24 +12,12 @@ public class BetterThirdPersonManager extends ModManager {
     }
 
     public Dodge.DodgeDirection handleCustomCameraRotationForDodge(Dodge.DodgeDirection direction) {
-        if (!isInstalled()) return direction;
-        if (!Minecraft.getInstance().options.getCameraType().isFirstPerson()) {
-            ClientPlayerEntity player = Minecraft.getInstance().player;
-            if (player == null) return direction;
-            if (!BetterThirdPerson.getCameraManager().hasCustomCamera()) return direction;
-            CustomCamera camera = BetterThirdPerson.getCameraManager().getCustomCamera();
-            float yaw = MathUtil.normalizeDegree(camera.getPlayerRotation().getYaw() - camera.getCameraRotation().getYaw());
-            float yawAbs = Math.abs(yaw);
-            if (yawAbs < 45) {
-                return direction;
-            } else if (yawAbs > 135) {
-                return direction.inverse();
-            } else if (yaw < 0) {
-                return direction.right();
-            } else {
-                return direction.left();
-            }
-        }
-        return direction;
+        return isCameraDecoupled() ? Dodge.DodgeDirection.Front : direction;
+    }
+
+    public boolean isCameraDecoupled() {
+        return isInstalled()
+            && !Minecraft.getInstance().options.getCameraType().isFirstPerson()
+            && BetterThirdPerson.getCameraManager().hasCustomCamera();
     }
 }

--- a/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
+++ b/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
@@ -1,12 +1,11 @@
 package com.alrex.parcool.extern.shouldersurfing;
 
 import com.alrex.parcool.common.action.impl.Dodge;
+import com.alrex.parcool.common.action.impl.Dodge.DodgeDirection;
 import com.alrex.parcool.extern.ModManager;
-import com.alrex.parcool.utilities.MathUtil;
-import com.github.exopandora.shouldersurfing.api.client.IShoulderSurfingCamera;
 import com.github.exopandora.shouldersurfing.api.client.ShoulderSurfing;
+import com.github.exopandora.shouldersurfing.config.Config;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.entity.player.ClientPlayerEntity;
 
 public class ShoulderSurfingManager extends ModManager {
     public ShoulderSurfingManager() {
@@ -14,24 +13,13 @@ public class ShoulderSurfingManager extends ModManager {
     }
 
     public Dodge.DodgeDirection handleCustomCameraRotationForDodge(Dodge.DodgeDirection direction) {
-        if (!isInstalled()) return direction;
-        if (!Minecraft.getInstance().options.getCameraType().isFirstPerson()) {
-            if (!ShoulderSurfing.getInstance().isShoulderSurfing()) return direction;
-            ClientPlayerEntity player = Minecraft.getInstance().player;
-            if (player == null) return direction;
-            IShoulderSurfingCamera camera = ShoulderSurfing.getInstance().getCamera();
-            float yaw = MathUtil.normalizeDegree(camera.getYRot() - player.yRot);
-            float yawAbs = Math.abs(yaw);
-            if (yawAbs < 45) {
-                return direction;
-            } else if (yawAbs > 135) {
-                return direction.inverse();
-            } else if (yaw < 0) {
-                return direction.left();
-            } else {
-                return direction.right();
-            }
-        }
-        return direction;
+        return isCameraDecoupled() ? DodgeDirection.Front : direction;
+    }
+
+    public Boolean isCameraDecoupled() {
+        return isInstalled()
+            && !Minecraft.getInstance().options.getCameraType().isFirstPerson()
+            && ShoulderSurfing.getInstance().isShoulderSurfing()
+            && Config.CLIENT.isCameraDecoupled();
     }
 }

--- a/src/main/java/com/alrex/parcool/utilities/EntityUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/EntityUtil.java
@@ -7,4 +7,10 @@ public class EntityUtil {
 	public static void addVelocity(Entity entity, Vector3d vec) {
 		entity.setDeltaMovement(entity.getDeltaMovement().add(vec));
 	}
+
+	public static void setYRot(Entity entity, float yRot) {
+		entity.setYBodyRot(yRot);
+		entity.setYHeadRot(yRot);
+		entity.yRot = yRot;
+	}
 }

--- a/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
@@ -1,8 +1,12 @@
 package com.alrex.parcool.utilities;
 
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.vector.Vector2f;
 import net.minecraft.util.math.vector.Vector3d;
 
 public class VectorUtil {
+	private static final float DEG_TO_RAD = (float)(Math.PI / 180D);
+
 	public static double toYawDegree(Vector3d vec) {
 		return (Math.atan2(vec.z(), vec.x()) * 180.0 / Math.PI - 90);
 	}
@@ -17,5 +21,27 @@ public class VectorUtil {
 
 	public static Vector3d fromYawDegree(double degree) {
 		return new Vector3d(-Math.sin(Math.toRadians(degree)), 0, Math.cos(Math.toRadians(degree)));
+	}
+	
+	public static Vector3d rotateYDegrees(Vector3d vector, float baseAngle)
+	{
+		float angle = baseAngle * DEG_TO_RAD;
+		return new Vector3d(vector.x * MathHelper.cos(angle) - vector.z * MathHelper.sin(angle), vector.y, vector.x * MathHelper.sin(angle) + vector.z * MathHelper.cos(angle));
+	}
+
+	public static float toYaw(Vector3d vector) {
+		return (float)Math.toDegrees(Math.atan2(-vector.x, vector.z));
+	}
+
+	public static boolean isZero(Vector3d vector) {
+		return vector.x == 0 && vector.y == 0 && vector.z == 0;
+	}
+
+	public static boolean isZero(Vector2f vector) {
+		return vector.x == 0 && vector.y == 0;
+	}
+
+	public static double getLength(Vector2f vector) {
+		return Math.sqrt(vector.x * vector.x + vector.y * vector.y);
 	}
 }


### PR DESCRIPTION
Backporting change done for 1.18.2.

Making dodge have a different behavior when camera is decoupled.,: always being forward and making character turn to the dodging direction, which behaves better with a decoupled camera.

Edit: @alRex-U I'm sorry. i thought I could easily do a port of these changes to 1.18.1-new because shoulder surfing released the Coupled Camera API for 1.18.1, but the branch here is way behind, so I was unable to.