### PR TITLE
fix: dodge compatibility with BetterThirdPerson

### DIFF
--- a/src/main/java/com/alrex/parcool/ParCool.java
+++ b/src/main/java/com/alrex/parcool/ParCool.java
@@ -4,6 +4,7 @@ import com.alrex.parcool.api.Attributes;
 import com.alrex.parcool.api.Effects;
 import com.alrex.parcool.api.SoundEvents;
 import com.alrex.parcool.client.input.KeyBindings;
+import com.alrex.parcool.client.input.KeyRecorder;
 import com.alrex.parcool.client.renderer.Renderers;
 import com.alrex.parcool.common.block.Blocks;
 import com.alrex.parcool.common.block.TileEntities;
@@ -27,6 +28,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -79,6 +81,7 @@ public class ParCool {
 		MinecraftForge.EVENT_BUS.register(this);
 		MinecraftForge.EVENT_BUS.addListener(Limitations::init);
 		MinecraftForge.EVENT_BUS.addListener(Limitations::save);
+		MinecraftForge.EVENT_BUS.addListener(EventPriority.LOW, KeyRecorder::onInputs);
 
 		Blocks.register(FMLJavaModLoadingContext.get().getModEventBus());
 		Items.register(FMLJavaModLoadingContext.get().getModEventBus());

--- a/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
+++ b/src/main/java/com/alrex/parcool/client/input/KeyRecorder.java
@@ -1,7 +1,12 @@
 package com.alrex.parcool.client.input;
 
 import javax.annotation.Nullable;
+import com.alrex.parcool.extern.AdditionalMods;
+import com.alrex.parcool.utilities.VectorUtil;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.util.MovementInputFromOptions;
+import net.minecraft.util.math.vector.Vector2f;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -79,7 +84,20 @@ public class KeyRecorder {
 	}
 
 	private static void recordMovingVector(boolean isMoving) {
-		if (isMoving) lastDirection = KeyBindings.getCurrentMoveVector();
+		if (isMoving && !AdditionalMods.betterThirdPerson().isCameraDecoupled()) {
+			lastDirection = KeyBindings.getCurrentMoveVector();
+		}
+	}
+
+	public static void recordMovingVector(MovementInputFromOptions moving) {
+		if (!AdditionalMods.betterThirdPerson().isCameraDecoupled()) return;
+		Vector2f vector = moving.getMoveVector();
+		if (!VectorUtil.isZero(vector)) {
+			Vector3d newDirection = new Vector3d(vector.x, 0, vector.y).normalize();
+			Minecraft mc = Minecraft.getInstance();
+			newDirection = VectorUtil.rotateYDegrees(newDirection, mc.player.yRot);
+			lastDirection = newDirection;
+		}
 	}
 
 	public static class KeyState {

--- a/src/main/java/com/alrex/parcool/common/action/impl/Dodge.java
+++ b/src/main/java/com/alrex/parcool/common/action/impl/Dodge.java
@@ -142,7 +142,9 @@ public class Dodge extends Action {
 			if (KeyBindings.isKeyForwardDown()) direction = DodgeDirection.Front;
 			if (KeyBindings.isKeyLeftDown()) direction = DodgeDirection.Left;
 			if (KeyBindings.isKeyRightDown()) direction = DodgeDirection.Right;
-			if (direction != null) dodgeVec = KeyBindings.getCurrentMoveVector();
+			if (direction != null && !AdditionalMods.betterThirdPerson().isCameraDecoupled()) {
+				dodgeVec = KeyBindings.getCurrentMoveVector();
+			}
 		}
 		if (direction == null || dodgeVec == null) return false;
 		direction = AdditionalMods.betterThirdPerson().handleCustomCameraRotationForDodge(direction);

--- a/src/main/java/com/alrex/parcool/extern/AdditionalMods.java
+++ b/src/main/java/com/alrex/parcool/extern/AdditionalMods.java
@@ -2,7 +2,6 @@ package com.alrex.parcool.extern;
 
 import com.alrex.parcool.extern.betterthirdperson.BetterThirdPersonManager;
 import com.alrex.parcool.extern.shouldersurfing.ShoulderSurfingManager;
-
 import java.util.Arrays;
 import java.util.function.Supplier;
 
@@ -29,9 +28,5 @@ public enum AdditionalMods {
 
     public static void init() {
         Arrays.stream(values()).map(AdditionalMods::get).forEach(ModManager::init);
-    }
-
-    public static boolean isCameraDecoupled() {
-        return shoulderSurfingManager().isCameraDecoupled() || betterThirdPerson().isCameraDecoupled();
     }
 }

--- a/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
+++ b/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
@@ -4,7 +4,6 @@ import com.alrex.parcool.common.action.impl.Dodge;
 import com.alrex.parcool.extern.ModManager;
 import io.socol.betterthirdperson.BetterThirdPerson;
 import net.minecraft.client.Minecraft;
-import net.minecraft.entity.Entity;
 
 public class BetterThirdPersonManager extends ModManager {
     public BetterThirdPersonManager() {

--- a/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
+++ b/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
@@ -4,6 +4,7 @@ import com.alrex.parcool.common.action.impl.Dodge;
 import com.alrex.parcool.extern.ModManager;
 import io.socol.betterthirdperson.BetterThirdPerson;
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
 
 public class BetterThirdPersonManager extends ModManager {
     public BetterThirdPersonManager() {
@@ -18,5 +19,10 @@ public class BetterThirdPersonManager extends ModManager {
         return isInstalled()
             && !Minecraft.getInstance().options.getCameraType().isFirstPerson()
             && BetterThirdPerson.getCameraManager().hasCustomCamera();
+    }
+
+    public Float getCameraYaw() {
+        if (!isCameraDecoupled()) return null;
+        return BetterThirdPerson.getCameraManager().getCustomCamera().getYaw();
     }
 }

--- a/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
+++ b/src/main/java/com/alrex/parcool/extern/betterthirdperson/BetterThirdPersonManager.java
@@ -1,7 +1,6 @@
 package com.alrex.parcool.extern.betterthirdperson;
 
 import com.alrex.parcool.common.action.impl.Dodge;
-import com.alrex.parcool.extern.AdditionalMods;
 import com.alrex.parcool.extern.ModManager;
 import io.socol.betterthirdperson.BetterThirdPerson;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
+++ b/src/main/java/com/alrex/parcool/extern/shouldersurfing/ShoulderSurfingManager.java
@@ -22,4 +22,9 @@ public class ShoulderSurfingManager extends ModManager {
             && ShoulderSurfing.getInstance().isShoulderSurfing()
             && Config.CLIENT.isCameraDecoupled();
     }
+
+    public Float getCameraYaw() {
+        if (!isCameraDecoupled()) return null;
+        return ShoulderSurfing.getInstance().getCamera().getYRot();
+    }
 }

--- a/src/main/java/com/alrex/parcool/mixin/client/MovementInputMixin.java
+++ b/src/main/java/com/alrex/parcool/mixin/client/MovementInputMixin.java
@@ -18,6 +18,6 @@ public class MovementInputMixin {
       )
    )
    public void tickHook(boolean moveSlowly, CallbackInfo ci) {
-      KeyRecorder.recordMovingVector((MovementInputFromOptions)(Object)this);
+      KeyRecorder.recordKeyboardMovingVector((MovementInputFromOptions)(Object)this);
    }
 }

--- a/src/main/java/com/alrex/parcool/mixin/client/MovementInputMixin.java
+++ b/src/main/java/com/alrex/parcool/mixin/client/MovementInputMixin.java
@@ -1,0 +1,23 @@
+package com.alrex.parcool.mixin.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.At;
+import com.alrex.parcool.client.input.KeyRecorder;
+import net.minecraft.util.MovementInputFromOptions;
+
+@Mixin({MovementInputFromOptions.class})
+public class MovementInputMixin {
+   @Inject(
+      method = {"tick"},
+      at = @At(
+         value = "FIELD",
+         target = "Lnet/minecraft/util/MovementInputFromOptions;shiftKeyDown:Z",
+         shift = At.Shift.AFTER  // Execute after the field assignment
+      )
+   )
+   public void tickHook(boolean moveSlowly, CallbackInfo ci) {
+      KeyRecorder.recordMovingVector((MovementInputFromOptions)(Object)this);
+   }
+}

--- a/src/main/java/com/alrex/parcool/utilities/CameraUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/CameraUtil.java
@@ -18,11 +18,11 @@ public class CameraUtil {
         return Minecraft.getInstance().cameraEntity.yRot;
     }
 
-	public static Vector3d alignVectorToCamera(Vector3d vector) {
-		if (vector == null) return null;
-		Minecraft mc = Minecraft.getInstance();
-		if (mc.player == null) return vector;
-		Float cameraYaw = getCameraYaw();
-		return VectorUtil.rotateYDegrees(vector, cameraYaw);
-	}
+    public static Vector3d alignVectorToCamera(Vector3d vector) {
+        if (vector == null) return null;
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player == null) return vector;
+        Float cameraYaw = getCameraYaw();
+        return VectorUtil.rotateYDegrees(vector, cameraYaw);
+    }
 }

--- a/src/main/java/com/alrex/parcool/utilities/CameraUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/CameraUtil.java
@@ -1,0 +1,28 @@
+package com.alrex.parcool.utilities;
+
+import javax.annotation.Nullable;
+import com.alrex.parcool.extern.AdditionalMods;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.math.vector.Vector3d;
+
+public class CameraUtil {
+    public static boolean isCameraDecoupled() {
+        return AdditionalMods.shoulderSurfingManager().isCameraDecoupled() || AdditionalMods.betterThirdPerson().isCameraDecoupled();
+    }
+
+    public static float getCameraYaw() {
+        @Nullable Float yaw = AdditionalMods.shoulderSurfingManager().getCameraYaw();
+        if (yaw != null) return yaw;
+        yaw = AdditionalMods.betterThirdPerson().getCameraYaw();
+        if (yaw != null) return yaw;
+        return Minecraft.getInstance().cameraEntity.yRot;
+    }
+
+	public static Vector3d alignVectorToCamera(Vector3d vector) {
+		if (vector == null) return null;
+		Minecraft mc = Minecraft.getInstance();
+		if (mc.player == null) return vector;
+		Float cameraYaw = getCameraYaw();
+		return VectorUtil.rotateYDegrees(vector, cameraYaw);
+	}
+}

--- a/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
@@ -1,5 +1,9 @@
 package com.alrex.parcool.utilities;
 
+import com.alrex.parcool.ParCool;
+import com.alrex.parcool.extern.AdditionalMods;
+
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector2f;
 import net.minecraft.util.math.vector.Vector3d;

--- a/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
+++ b/src/main/java/com/alrex/parcool/utilities/VectorUtil.java
@@ -1,9 +1,5 @@
 package com.alrex.parcool.utilities;
 
-import com.alrex.parcool.ParCool;
-import com.alrex.parcool.extern.AdditionalMods;
-
-import net.minecraft.client.Minecraft;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector2f;
 import net.minecraft.util.math.vector.Vector3d;

--- a/src/main/resources/parcool.mixins.json
+++ b/src/main/resources/parcool.mixins.json
@@ -11,7 +11,8 @@
     "client.GameSettingsMixin",
     "client.LivingRendererMixin",
     "client.PlayerModelMixin",
-    "client.PlayerRendererMixin"
+    "client.PlayerRendererMixin",
+    "client.MovementInputMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Solves #383

MovementInputMixin captures keyboard movement input at its most raw moment, and serves the purpose of accessing its values before any transformation Minecraft or BetterThirdPerson do. It'll always provide a movement vector not even aligned with world coordinates.

The InputUpdateEvent is the second entry point for movement events, which will serve the purpose of capturing movements done by gamepads. An if is made to ignore the event if a keyboard movement input has not been consumed yet. Why? Because BetterThirdPerson captures both moments and manipulates the vector in both of them, we need to do the same in order not to access already transformed inputs.

When the captured vector is consumed, an alignment to the current camera is done so it'll correspond to the direction the player wants. The camera can be defined by BetterThirdPerson, ShoulderSurfing, or the vanilla one, depending on which option the player is using. The alignment is only done during the getLastMoveVector call as it'll be called by the Dodge action once it confirms a dodge must be done, so we avoid doing unneeded calculations at each input, and we give a chance to the camera mods to do their thing with the perspective.

This way, we solve keyboard and gamepad users, and they have a working dodge with BetterThirdPerson.

This approach has also been tested with ShoulderSurfing and Vanilla Camera, and it works equally with every one of them.

~I haven't tested it with Controlify, though, as it doesn't support Minecraft 1.16.5 or Forge. I'll revisit the topic once this PR is accepted and the modification is ported to a compatible version. I tested it only with controllable.~ Also tested with controlify (see #390)