### PR TITLE
1.21.1 nf #429 fov flicker issue fix

### DIFF
--- a/src/main/java/com/alrex/parcool/mixin/client/LocalPlayerMixin.java
+++ b/src/main/java/com/alrex/parcool/mixin/client/LocalPlayerMixin.java
@@ -18,32 +18,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(LocalPlayer.class)
 public abstract class LocalPlayerMixin extends AbstractClientPlayer {
 
-    private boolean oldSprinting = false;
-
-	public LocalPlayerMixin(ClientLevel p_250460_, GameProfile p_249912_) {
+    public LocalPlayerMixin(ClientLevel p_250460_, GameProfile p_249912_) {
         super(p_250460_, p_249912_);
     }
 
     @Inject(method = "isShiftKeyDown", at = @At("HEAD"), cancellable = true)
-	public void onIsShiftKeyDown(CallbackInfoReturnable<Boolean> cir) {
-		Parkourability parkourability = Parkourability.get((Player) (Object) this);
+    public void onIsShiftKeyDown(CallbackInfoReturnable<Boolean> cir) {
+        Parkourability parkourability = Parkourability.get((Player) (Object) this);
 
-		if (parkourability == null) return;
+        if (parkourability == null) return;
         if (parkourability.getBehaviorEnforcer().cancelSneak()) {
-			cir.setReturnValue(false);
-		}
-	}
-
-    @Inject(method = "aiStep", at = @At("HEAD"))
-	public void onAiStep(CallbackInfo ci) {
-        var player = (LocalPlayer) (Object) this;
-        if (player.isLocalPlayer()) {
-            boolean flag = !player.input.hasForwardImpulse() || !((float) player.getFoodData().getFoodLevel() > 6.0F || this.getAbilities().mayfly);
-            boolean flag1 = flag || this.isInWater() && !this.isUnderWater();
-            if (oldSprinting && !flag1) {
-                player.setSprinting(true);
-            }
-            oldSprinting = player.isSprinting();
+            cir.setReturnValue(false);
         }
     }
 

--- a/src/main/java/com/alrex/parcool/mixin/common/PlayerMixin.java
+++ b/src/main/java/com/alrex/parcool/mixin/common/PlayerMixin.java
@@ -1,6 +1,8 @@
 package com.alrex.parcool.mixin.common;
 
+import com.alrex.parcool.common.action.impl.FastRun;
 import com.alrex.parcool.common.attachment.common.Parkourability;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -16,7 +18,8 @@ public abstract class PlayerMixin extends LivingEntity {
 
     protected PlayerMixin(EntityType<? extends LivingEntity> p_i48577_1_, Level p_i48577_2_) {
         super(p_i48577_1_, p_i48577_2_);
-	}
+    }
+
     @Inject(method = "tryToStartFallFlying", at = @At("HEAD"), cancellable = true)
     public void onTryToStartFallFlying(CallbackInfoReturnable<Boolean> cir) {
         var player = (Player) (Object) this;
@@ -42,5 +45,10 @@ public abstract class PlayerMixin extends LivingEntity {
         if (parkourability.getBehaviorEnforcer().cancelDescendFromEdge()) {
             cir.setReturnValue(true);
         }
+    }
+
+    @WrapWithCondition(method = "attack", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;setSprinting(Z)V"))
+    public boolean wrapSetSprinting(Player instance, boolean b) {
+        return !Parkourability.get(instance).get(FastRun.class).isDoing();
     }
 }


### PR DESCRIPTION
To fix [#429](https://github.com/alRex-U/ParCool/issues/429) without reintroducing [#414](https://github.com/alRex-U/ParCool/issues/414), this should be the correct solution.
I believe FastRun is a superset of the vanilla sprint in terms of design, so it shouldn’t attempt to modify the vanilla sprinting state.
This should fix the issue, although I’m not entirely sure about the compatibility with other mods.