### PR TITLE
Avoid using @SubscribeEvent to prevent fully scanning classes

### DIFF
--- a/src/main/java/com/alrex/parcool/common/action/ActionProcessor.java
+++ b/src/main/java/com/alrex/parcool/common/action/ActionProcessor.java
@@ -49,7 +49,6 @@ public class ActionProcessor {
 	private int staminaSyncCoolTimeTick = 0;
 
 
-	@SubscribeEvent
 	public void onTick(PlayerTickEvent.Post event) {
 		var player = event.getEntity();
 		Parkourability parkourability = Parkourability.get(player);
@@ -99,6 +98,7 @@ public class ActionProcessor {
 		animation.tick(clientPlayer, parkourability);
 	}
 
+    @OnlyIn(Dist.CLIENT)
 	private void onTick$doPostProcessInClient(PlayerTickEvent event, Parkourability parkourability) {
 		if (!(event.getEntity() instanceof LocalPlayer player)) return;
 		staminaSyncCoolTimeTick++;
@@ -251,6 +251,7 @@ public class ActionProcessor {
 		buffer.flip();
 	}
 
+    @OnlyIn(Dist.CLIENT)
 	private void consumeStamina(Player player, int value) {
 		if (player instanceof LocalPlayer localPlayer) {
 			LocalStamina.get(localPlayer).consume(localPlayer, value);
@@ -260,7 +261,6 @@ public class ActionProcessor {
 	// ====
 
 	@OnlyIn(Dist.CLIENT)
-	@SubscribeEvent
 	public void onRenderTick(RenderFrameEvent.Pre event) {
 		Player clientPlayer = Minecraft.getInstance().player;
 		if (clientPlayer == null) return;
@@ -278,7 +278,6 @@ public class ActionProcessor {
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	@SubscribeEvent
 	public void onViewRender(ViewportEvent.ComputeCameraAngles event) {
         LocalPlayer player = Minecraft.getInstance().player;
 		if (player == null) return;

--- a/src/main/java/com/alrex/parcool/common/registries/EventBusForgeRegistry.java
+++ b/src/main/java/com/alrex/parcool/common/registries/EventBusForgeRegistry.java
@@ -8,6 +8,8 @@ import com.alrex.parcool.common.potion.ParCoolBrewingRecipe;
 import net.neoforged.bus.api.IEventBus;
 
 public class EventBusForgeRegistry {
+    private static final ActionProcessor ACTION_PROCESSOR = new ActionProcessor();
+
 	public static void register(IEventBus bus) {
         bus.register(ParCoolBrewingRecipe.class);
         bus.register(PlayerJumpHandler.class);
@@ -15,7 +17,8 @@ public class EventBusForgeRegistry {
         bus.register(PlayerVisibilityHandler.class);
         bus.register(PlayerDamageHandler.class);
         bus.register(PlayerCloneHandler.class);
-		bus.register(new ActionProcessor());
+
+        bus.addListener(ACTION_PROCESSOR::onTick);
 	}
 
 	public static void registerClient(IEventBus bus) {
@@ -25,5 +28,8 @@ public class EventBusForgeRegistry {
         bus.register(PlayerJoinHandler.class);
         bus.register(HUDManager.getInstance());
         bus.register(InputHandler.class);
+
+        bus.addListener(ACTION_PROCESSOR::onRenderTick);
+        bus.addListener(ACTION_PROCESSOR::onViewRender);
 	}
 }


### PR DESCRIPTION
`@SubscribeEvent` fully scans the class even in a dedicated server, leading to the crash, `Invalid Dist`

And to avoid referencing methods with client-side code, annotated `@OnlyIn(Dist.CLIENT)`

_Demonstration:_ 

<img width="1523" height="802" alt="image" src="https://github.com/user-attachments/assets/f74c7203-ab58-4fb2-a8ec-47a0fb3e7702" />

ParCool + Epic Fight + Epic ParCool works in a dedicated server.