### PR TITLE
1.21.1 nf animator fix

### DIFF
--- a/src/main/java/com/alrex/parcool/client/animation/impl/JumpChargingAnimator.java
+++ b/src/main/java/com/alrex/parcool/client/animation/impl/JumpChargingAnimator.java
@@ -17,10 +17,7 @@ public class JumpChargingAnimator extends Animator {
 
     @Override
     public boolean animatePre(Player player, Parkourability parkourability, PlayerModelTransformer transformer) {
-        float transitionPhase = Math.min(1f, (parkourability.get(ChargeJump.class).getChargingTick() + transformer.getPartialTick()) / ChargeJump.JUMP_MAX_CHARGE_TICK);
-        float animFactor = new Easing(transitionPhase)
-                .sinInOut(0, 1, 0, 1)
-                .get();
+        float animFactor = getAnimFactor(parkourability, transformer.getPartialTick());
         transformer
                 .translateLeftLeg(
                         0,
@@ -53,14 +50,20 @@ public class JumpChargingAnimator extends Animator {
 
     @Override
     public boolean rotatePre(Player player, Parkourability parkourability, PlayerModelRotator rotator) {
-        float transitionPhase = Math.min(1f, (parkourability.get(ChargeJump.class).getChargingTick() + rotator.getPartialTick()) / ChargeJump.JUMP_MAX_CHARGE_TICK);
-        float animFactor = new Easing(transitionPhase)
-                .sinInOut(0, 1, 0, 1)
-                .get();
+        float animFactor = getAnimFactor(parkourability, rotator.getPartialTick());
         rotator
                 .rotateYawRightward(180f + rotator.getYRot())
                 .translate(0, 0f, 0.3f * animFactor)
                 .rotatePitchFrontward(25 * animFactor);
         return true;
+    }
+
+    private float getAnimFactor(Parkourability parkourability, float partialTick) {
+        partialTick *= (parkourability.get(ChargeJump.class).getNotChargingTick() == 0 ? 1 : -1);
+        float transitionPhase = Math.min(1f, (parkourability.get(ChargeJump.class).getChargingTick() + partialTick) / ChargeJump.JUMP_MAX_CHARGE_TICK);
+        float animFactor = new Easing(transitionPhase)
+                .sinInOut(0, 1, 0, 1)
+                .get();
+        return animFactor;
     }
 }

--- a/src/main/java/com/alrex/parcool/client/animation/impl/SlidingAnimator.java
+++ b/src/main/java/com/alrex/parcool/client/animation/impl/SlidingAnimator.java
@@ -14,16 +14,13 @@ public class SlidingAnimator extends Animator {
 	private static final int MAX_TRANSITION_TICK = 5;
 	@Override
 	public boolean shouldRemoved(Player player, Parkourability parkourability) {
-		return !parkourability.get(Slide.class).isDoing();
+        Slide slide = parkourability.get(Slide.class);
+        return !slide.isDoing() && slide.getNotDoingTick() >= MAX_TRANSITION_TICK;
 	}
 
 	@Override
 	public void animatePost(Player player, Parkourability parkourability, PlayerModelTransformer transformer) {
-		float animFactor = (getTick() + transformer.getPartialTick()) / MAX_TRANSITION_TICK;
-		if (animFactor > 1) animFactor = 1;
-		animFactor = new Easing(animFactor)
-				.sinInOut(0, 1, 0, 1)
-				.get();
+        float animFactor = getAnimFactor(parkourability, transformer.getPartialTick());
 
 		transformer
                 .translateLeftLeg(
@@ -53,12 +50,8 @@ public class SlidingAnimator extends Animator {
     public boolean rotatePre(Player player, Parkourability parkourability, PlayerModelRotator rotator) {
         Vec3 vec = parkourability.get(Slide.class).getSlidingVector();
         if (vec == null) return false;
-        float animFactor = (getTick() + rotator.getPartialTick()) / MAX_TRANSITION_TICK;
-        float yRot = (float) VectorUtil.toYawDegree(vec);
-        if (animFactor > 1) animFactor = 1;
-        animFactor = new Easing(animFactor)
-                .sinInOut(0, 1, 0, 1)
-				.get();
+        float animFactor = getAnimFactor(parkourability, rotator.getPartialTick());
+        float yRot = parkourability.get(Slide.class).isDoing() ? (float) VectorUtil.toYawDegree(vec) : rotator.getYRot();
 		rotator
                 .rotateYawRightward(180f + yRot)
                 .rotatePitchFrontward(-55f * animFactor)
@@ -67,4 +60,18 @@ public class SlidingAnimator extends Animator {
                 .translate(0, -0.7f * animFactor, -0.3f * animFactor);
         return true;
 	}
+
+    private float getAnimFactor(Parkourability parkourability, float partialTick) {
+        Slide slide = parkourability.get(Slide.class);
+        boolean doing = slide.isDoing();
+        int tick = doing ? getTick() : slide.getNotDoingTick();
+        float animFactor = Math.min((tick + partialTick) / MAX_TRANSITION_TICK, 1);
+        if (!doing) {
+            animFactor = 1 - animFactor;
+        }
+        animFactor = new Easing(animFactor)
+                .sinInOut(0, 1, 0, 1)
+                .get();
+        return animFactor;
+    }
 }

--- a/src/main/java/com/alrex/parcool/common/action/impl/ChargeJump.java
+++ b/src/main/java/com/alrex/parcool/common/action/impl/ChargeJump.java
@@ -175,4 +175,8 @@ public class ChargeJump extends Action {
     public int getChargingTick() {
         return chargeTick;
     }
+
+    public int getNotChargingTick() {
+        return notChargeTick;
+    }
 }

--- a/src/main/java/com/alrex/parcool/common/action/impl/Slide.java
+++ b/src/main/java/com/alrex/parcool/common/action/impl/Slide.java
@@ -101,6 +101,10 @@ public class Slide extends Action {
 		if (animation != null && !animation.hasAnimator()) {
 			animation.setAnimator(new CrawlAnimator());
 		}
+        if (!Parkourability.get(player).get(Crawl.class).isDoing()) {
+            player.swimAmount = 0;
+            player.swimAmountO = 0;
+        }
 	}
 
 	@Override
@@ -109,6 +113,10 @@ public class Slide extends Action {
 		if (animation != null && !animation.hasAnimator()) {
 			animation.setAnimator(new CrawlAnimator());
 		}
+        if (!Parkourability.get(player).get(Crawl.class).isDoing()) {
+            player.swimAmount = 0;
+            player.swimAmountO = 0;
+        }
 	}
 
     @Nullable

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -7,3 +7,5 @@ public net.minecraft.client.renderer.RenderStateShard f_173075_ # RENDERTYPE_LEA
 public net.minecraft.world.entity.Entity onGround # onGround
 public net.minecraft.world.damagesource.DamageSources *()
 public net.minecraft.world.entity.player.Player canPlayerFitWithinBlocksAndEntitiesWhen(Lnet/minecraft/world/entity/Pose;)Z # canPlayerFitWithinBlocksAndEntitiesWhen
+public net.minecraft.world.entity.LivingEntity swimAmount
+public net.minecraft.world.entity.LivingEntity swimAmountO


### PR DESCRIPTION
This PR adds a proper end transition to the Slide animation, implementing the intent of [#442](https://github.com/alRex-U/ParCool/pull/442)
 using the Animator system as a more robust solution.

For the Slide action:

The player's swimAmount is cleared when the action stops to eliminate interference from the vanilla swimming animation.

SlidingAnimator now applies a short inverse animation (5 ticks) after the action ends, creating a smoother visual transition instead of an abrupt stop.

Additionally, this PR fixes an issue in JumpChargingAnimator that caused the charging animation to become visually choppy near the end.

The root cause was improper handling of partial ticks after charging stopped:

The integer charging tick was decrementing as expected,

but the partial tick continued increasing,
resulting in inconsistent accumulated values and visible jitter.

This PR resolves the issue by reversing the partial tick progression when not charging, ensuring smooth interpolation during the release phase.