### PR TITLE
1.21.1 nf crawl fix

### DIFF
--- a/src/main/java/com/alrex/parcool/mixin/client/PlayerRendererMixin.java
+++ b/src/main/java/com/alrex/parcool/mixin/client/PlayerRendererMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
+import net.minecraft.util.Mth;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -48,4 +49,13 @@ public abstract class PlayerRendererMixin extends LivingEntityRenderer<AbstractC
             ci.cancel();
         }
 	}
+
+    @Inject(method = "setupRotations(Lnet/minecraft/client/player/AbstractClientPlayer;Lcom/mojang/blaze3d/vertex/PoseStack;FFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;mulPose(Lorg/joml/Quaternionf;)V", ordinal = 2, shift = At.Shift.AFTER))
+    private void onMulPose(AbstractClientPlayer player, PoseStack poseStack, float bob, float yBodyRot, float partialTick, float scale, CallbackInfo ci) {
+        var swimAmount = player.getSwimAmount(partialTick);
+        var swimming = player.isVisuallySwimming();
+        var yOffset = swimming ? Mth.lerp(swimAmount, 1.0, 0.0) : Mth.lerp(swimAmount, 0.0, -1.0);
+        var zOffset = swimming ? Mth.lerp(swimAmount, -0.3, 0.0) : Mth.lerp(swimAmount, 0.0, 0.3);
+        poseStack.translate(0.0, yOffset, zOffset);
+    }
 }


### PR DESCRIPTION
Hello, I would like to ask whether it would be possible to add a transition to the Crawl animation (which relies on the vanilla swimAmount animation).

SlidingAnimator already implements a proper end transition, so it seems reasonable for Crawl to have a similar treatment.

Currently, in PlayerRenderer, the vanilla game applies a fixed positional offset when the player is swimming. This results in some visual inconsistencies, especially when transitioning in or out of the crawl state.
<img width="1181" height="489" alt="image" src="https://github.com/user-attachments/assets/4893aff2-680a-43d0-a969-36aaf7334876" />
![PixPin_2026-03-03_23-48-43](https://github.com/user-attachments/assets/cc6d479c-507a-46c1-a419-9db72cbe1ed8)

In this PR, the issue is addressed by interpolating the offset value instead of applying it abruptly. An additional offset is applied dynamically to smooth the swimAmount transition.

After this fix:
![PixPin_2026-03-03_23-21-01](https://github.com/user-attachments/assets/2ea21ac4-dec9-4db1-94b7-caba05b0a07b)

I am not entirely certain whether this adjustment belongs in this mod, but since Crawl progression consistently depends on this behavior, it seems necessary to refine it here.