### PR TITLE
1.21.1-NF: vault no longer cancels fast run

### DIFF
--- a/src/main/java/com/alrex/parcool/common/action/impl/Vault.java
+++ b/src/main/java/com/alrex/parcool/common/action/impl/Vault.java
@@ -5,6 +5,7 @@ import com.alrex.parcool.client.animation.impl.KongVaultAnimator;
 import com.alrex.parcool.client.animation.impl.SpeedVaultAnimator;
 import com.alrex.parcool.client.input.KeyBindings;
 import com.alrex.parcool.common.action.Action;
+import com.alrex.parcool.common.action.BehaviorEnforcer;
 import com.alrex.parcool.common.action.StaminaConsumeTiming;
 import com.alrex.parcool.common.attachment.client.Animation;
 import com.alrex.parcool.common.attachment.common.Parkourability;
@@ -19,6 +20,8 @@ import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
 public class Vault extends Action {
+	private static final BehaviorEnforcer.ID ID_SPRINT_CANCEL = BehaviorEnforcer.newID();
+
 	public enum TypeSelectionMode {
 		SpeedVault, KongVault, Dynamic
 	}
@@ -106,6 +109,7 @@ public class Vault extends Action {
             player.playSound(SoundEvents.VAULT.get(), 1f, 1f);
 		stepDirection = new Vec3(startData.getDouble(), startData.getDouble(), startData.getDouble());
 		stepHeight = startData.getDouble();
+		parkourability.getBehaviorEnforcer().addMarkerCancellingSprint(ID_SPRINT_CANCEL, this::isDoing);
 		Animation animation = Animation.get(player);
 		if (animation != null && currentAnimation != null) {
 			switch (currentAnimation) {


### PR DESCRIPTION
Vaulting over obstacles cancels vanilla sprint due to horizontal block collision in the first couple ticks of the vault animation. Since FastRun.canContinue() requires player.isSprinting(), this caused fast run to stop mid-vault, leaving the player walking after the vault completes.

The fix registers a sprint cancel marker in Vault.onStartInLocalClient so that the LivingEntityMixin setSprinting hook blocks vanilla's cancellation for the duration of the vault. This is the same pattern already used by RideZipline.